### PR TITLE
Add support for filename de-duplication

### DIFF
--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -144,15 +144,19 @@ function processFile (file) {
             nextCount++
         }
         uniqueFilename = `${namePart}(${nextCount}).${extension}`
+
+        return { uniqueFilename, hash, nextCount }
     }
 
     if (hasDuplicateFilename) {
-        while (existingCounts.has(nextCount)) {
-            nextCount++
-        }
-        if (nextCount > 0) {
-            uniqueFilename = `${namePart}(${nextCount}).${extension}`
-        }
+      while (existingCounts.has(nextCount)) {
+          nextCount++
+      }
+      if (nextCount > 0) {
+          uniqueFilename = `${namePart}(${nextCount}).${extension}`
+      }
+
+      return { uniqueFilename, hash, nextCount }
     }
 
     return { uniqueFilename, hash, nextCount }

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -16,12 +16,20 @@ function buildRoutes (router) {
 
     // Check if the filename_hash column exists in the table schema
     const schema = instance.prepare("PRAGMA table_info('files')").all()
-    const columnExists = schema.some((column) => column.name === 'filename_hash')
+    const filenameHashColumnExists = schema.some((column) => column.name === 'filename_hash')
+    const duplicateCountColumnExists = schema.some((column) => column.name === 'duplicate_count')
 
-    // If the column does not exist, add it to the table schema
-    if (!columnExists) {
+    // If the filename_hash column does not exist, add it to the table schema
+    if (!filenameHashColumnExists) {
       instance.prepare(`
         ALTER TABLE files ADD COLUMN filename_hash VARCHAR(64)
+      `).run()
+    }
+
+    // If the duplicate_count column does not exist, add it to the table schema
+    if (!duplicateCountColumnExists) {
+      instance.prepare(`
+        ALTER TABLE files ADD COLUMN duplicate_count INTEGER DEFAULT 0
       `).run()
     }
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -10,15 +10,22 @@ function getHash (name) {
   return crypto.createHash('sha256').update(name).digest('hex')
 }
 
-// Get duplicate count from a filename or 0 if there isn't any
+// Extract duplicate count from a filename or returns 0 if there isn't any
 function extractDuplicateCount (filename) {
-  const regex = /\((\d+)\)./ // Match a number inside parentheses followed by a period
+  const regex = /\((\d+)\)/ // Matches a number inside parentheses
   const match = regex.exec(filename)
 
   if (match && match[1]) {
-      return parseInt(match[1])
+      const cleanedFilename = filename.replace(match[0], '') // Remove matched pattern from filename
+      return {
+          duplicateCount: parseInt(match[1]),
+          cleanedFilename,
+      }
   } else {
-      return 0
+      return {
+          duplicateCount: 0, // Return 0 if no match is found
+          cleanedFilename: filename,
+      }
   }
 }
 
@@ -57,8 +64,10 @@ function setupDb () {
 
   for (const row of rows) {
     const { id, filename } = row
-    const hash = getHash(filename)
-    const duplicateCount = extractDuplicateCount(filename)
+    const result = extractDuplicateCount(filename)
+    const duplicateCount = result.duplicateCount
+    const cleanedFilename = result.cleanedFilename
+    const hash = getHash(cleanedFilename)
     
     // Update the filename_hash column with the calculated hash value
     instance.prepare(`

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -129,7 +129,8 @@ function processFile (file) {
 
     let duplicateCounts = getDuplicateCounts(hash)
 
-    let nextCount = 1
+    const [namePart, extension] = file.name.split('.').length > 1 ? file.name.split('.') : [file.name, '']
+    let nextCount = duplicateCount !== 0 ? 1 : 0 // Initialize nextCount to 1 if filename already has a duplicate count, else 0
     let existingCounts = new Set(duplicateCounts.map((row) => row.duplicate_count))
 
     // Find duplicates of the original filename instead of the cleaned filename if adding it would create a duplicate
@@ -142,7 +143,6 @@ function processFile (file) {
         while (existingCounts.has(nextCount)) {
             nextCount++
         }
-        const [namePart, extension] = file.name.split('.').length > 1 ? file.name.split('.') : [file.name, '']
         uniqueFilename = `${namePart}(${nextCount}).${extension}`
     }
 
@@ -151,7 +151,6 @@ function processFile (file) {
             nextCount++
         }
         if (nextCount > 0) {
-            const [namePart, extension] = file.name.split('.').length > 1 ? file.name.split('.') : [file.name, '']
             uniqueFilename = `${namePart}(${nextCount}).${extension}`
         }
     }

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -96,7 +96,7 @@ function buildRoutes (router) {
     const hasDuplicateFilename = count > 0
     let uniqueFilename = file.name
 
-    let nextCount = 0
+    let nextCount = 1
     if (hasDuplicateFilename) {
       const duplicateCounts = db.instance.prepare(`
           SELECT duplicate_count FROM files
@@ -111,7 +111,7 @@ function buildRoutes (router) {
   
       const [namePart, extension] = file.name.split('.').length > 1 ? file.name.split('.') : [file.name, '']
       uniqueFilename = `${namePart}(${nextCount}).${extension}`
-  }
+    }
     const newFile = db.instance
       .prepare(`
         INSERT INTO files

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -135,6 +135,7 @@ function processFile (file) {
     // Create a unique filename if there is a duplicate filename
     if (hasDuplicateFilename) {
       // Find duplicates of the original filename instead of the cleaned filename if adding it would create a duplicate
+      // e.g. inputting kitten(1).jpg when kitten(1).jpg already exists in db should produce kitten(1)(1).jpg
       if (existingCounts.has(duplicateCount)) {
         // Re-calculate variables for original fileaname
         hash = getHash(file.name)

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,5 +1,6 @@
 const os = require('os')
 const db = require('db')
+const crypto = require('crypto')
 
 // SQLite usage
 // https://github.com/WiseLibs/better-sqlite3
@@ -11,6 +12,40 @@ function buildRoutes (router) {
   })
 
   router.get('/api/files', async (req, res) => {
+    const instance = db.instance
+
+    // Check if the filename_hash column exists in the table schema
+    const schema = instance.prepare("PRAGMA table_info('files')").all()
+    const columnExists = schema.some((column) => column.name === 'filename_hash')
+
+    // If the column does not exist, add it to the table schema
+    if (!columnExists) {
+      instance.prepare(`
+        ALTER TABLE files ADD COLUMN filename_hash VARCHAR(64)
+      `).run()
+    }
+
+    // Create an index for the filename_hash column
+    instance.prepare(`
+      CREATE INDEX IF NOT EXISTS idx_filename_hash ON files (filename_hash)
+    `).run()
+
+    // Select all rows from the files table
+    const rows = instance.prepare(`
+      SELECT id, filename FROM files WHERE filename_hash IS NULL
+    `).all()
+
+    // Update the filename_hash column for each row
+    for (const row of rows) {
+      const { id, filename } = row
+      const hash = crypto.createHash('sha256').update(filename).digest('hex')
+      
+      // Update the filename_hash column with the calculated hash value
+      instance.prepare(`
+        UPDATE files SET filename_hash = ? WHERE id = ?
+      `).run(hash, id)
+    }
+  
     const files = db.instance
       .prepare(`
         SELECT * FROM files
@@ -24,9 +59,9 @@ function buildRoutes (router) {
     const newFile = db.instance
       .prepare(`
         INSERT INTO files
-          (description, filename, mimetype, src)
+          (description, filename, mimetype, src, filename_hash)
           VALUES
-          (@description, @filename, @mimetype, @src)
+          (@description, @filename, @mimetype, @src, @filename_hash)
           RETURNING *
       `)
       .get({
@@ -34,6 +69,7 @@ function buildRoutes (router) {
         filename: file.name,
         mimetype: file.mimetype,
         src: file.base64,
+        filename_hash: crypto.createHash('sha256').update(file.name).digest('hex'),
       })
     return res.send(newFile)
   })

--- a/test/server/routes/index.test.js
+++ b/test/server/routes/index.test.js
@@ -106,19 +106,5 @@ describe('routes', function () {
       await router.postRoutes[route](req, res)
       expect(res.body.filename).to.equal('kitten(1)(1).jpg')
     })
-
-    it('if kitten(1).jpg exists, inputting kitten(1).jpg should change its name to kitten(1)(1).jpg', async function () {
-      const input = {
-        description: 'test',
-        file: {
-          name: 'kitten(1).jpg',
-          mimetype: 'image/jpg',
-          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
-        },
-      }
-      req.body = input
-      await router.postRoutes[route](req, res)
-      expect(res.body.filename).to.equal('kitten(1)(1).jpg')
-    })
   })
 })

--- a/test/server/routes/index.test.js
+++ b/test/server/routes/index.test.js
@@ -65,7 +65,7 @@ describe('routes', function () {
       expect(res.body.filename).to.equal('elvis(1).jpg')
     })
 
-    it('if kitten.jpg, kitten(1).jpg, and kitten(2).jpg exists, inputting kitten.jpg should set its name to kitten(3).jpg', async function () {
+    it('if kitten.jpg, kitten(1).jpg, and kitten(2).jpg exist, inputting kitten.jpg should set its name to kitten(3).jpg', async function () {
       const input = {
         description: 'test',
         file: {
@@ -105,6 +105,68 @@ describe('routes', function () {
       req.body = input
       await router.postRoutes[route](req, res)
       expect(res.body.filename).to.equal('kitten(1)(1).jpg')
+    })
+
+    it('if dog(2).jpg exists and dog.jpg and dog(1).jpg have been added, inputting dog.jpg should change its name to dog(3).jpg', async function () {
+      const preinput = {
+        description: 'test',
+        file: {
+          name: 'dog.jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = preinput
+      await router.postRoutes[route](req, res)
+
+      const preinput2 = {
+        description: 'test',
+        file: {
+          name: 'dog(1).jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = preinput2
+      await router.postRoutes[route](req, res)
+
+
+      const input = {
+        description: 'test',
+        file: {
+          name: 'dog.jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = input
+      await router.postRoutes[route](req, res)
+      expect(res.body.filename).to.equal('dog(3).jpg')
+    })
+
+    it('if dog(2).jpg exists and dog(2)(1).jpg has been added, inputting dog(2).jpg should change its name to dog(2)(2).jpg', async function () {
+      const preinput = {
+        description: 'test',
+        file: {
+          name: 'dog(2)(1).jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = preinput
+      await router.postRoutes[route](req, res)
+
+      const input = {
+        description: 'test',
+        file: {
+          name: 'dog(2).jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = input
+      await router.postRoutes[route](req, res)
+      expect(res.body.filename).to.equal('dog(2)(2).jpg')
     })
   })
 })

--- a/test/server/routes/index.test.js
+++ b/test/server/routes/index.test.js
@@ -28,6 +28,7 @@ describe('routes', function () {
   describe('POST /api/files', function () {
     beforeEach(async function () {
       route = '/api/files'
+      await router.getRoutes[route](req, res) // Call GET once
     })
 
     it('uploads a file and returns its metadata', async function () {
@@ -46,6 +47,78 @@ describe('routes', function () {
       expect(res.body.filename).to.equal(input.file.name)
       expect(res.body.mimetype).to.equal(input.file.mimetype)
       expect(res.body.src).to.equal(input.file.base64)
+      expect(res.body.filename_hash).to.equal('72ac3ece33d8e923a41bb2a4410418a9cd023309720f03ebca286ad59b284d3d')
+      expect(res.body.duplicate_count).to.equal(0)
+    })
+
+    it('if elvis.jpg exists, inputting elvis.jpg should set its name to elvis(1).jpg', async function () {
+      const input = {
+        description: 'test',
+        file: {
+          name: 'elvis.jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = input
+      await router.postRoutes[route](req, res)
+      expect(res.body.filename).to.equal('elvis(1).jpg')
+    })
+
+    it('if kitten.jpg, kitten(1).jpg, and kitten(2).jpg exists, inputting kitten.jpg should set its name to kitten(3).jpg', async function () {
+      const input = {
+        description: 'test',
+        file: {
+          name: 'kitten.jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = input
+      await router.postRoutes[route](req, res)
+      expect(res.body.filename).to.equal('kitten(3).jpg')
+    })
+
+    it('if dog(2).jpg exists, inputting dog.jpg should leave its name as is', async function () {
+      const input = {
+        description: 'test',
+        file: {
+          name: 'dog.jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = input
+      await router.postRoutes[route](req, res)
+      expect(res.body.filename).to.equal(input.file.name)
+    })
+
+    it('if kitten(1).jpg exists, inputting kitten(1).jpg should change its name to kitten(1)(1).jpg', async function () {
+      const input = {
+        description: 'test',
+        file: {
+          name: 'kitten(1).jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = input
+      await router.postRoutes[route](req, res)
+      expect(res.body.filename).to.equal('kitten(1)(1).jpg')
+    })
+
+    it('if kitten(1).jpg exists, inputting kitten(1).jpg should change its name to kitten(1)(1).jpg', async function () {
+      const input = {
+        description: 'test',
+        file: {
+          name: 'kitten(1).jpg',
+          mimetype: 'image/jpg',
+          base64: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+        },
+      }
+      req.body = input
+      await router.postRoutes[route](req, res)
+      expect(res.body.filename).to.equal('kitten(1)(1).jpg')
     })
   })
 })


### PR DESCRIPTION
Now when someone uploads a file with a duplicate filename in the DB, it will rewrite the new filename to a filename with a unique identifier.

This PR creates a `filename_hash` and `duplicate_count` column to keep track of duplicate filenames